### PR TITLE
Update production `PROJECT_URL`

### DIFF
--- a/project-configs.js
+++ b/project-configs.js
@@ -7,6 +7,6 @@ module.exports = {
   production: {
     PORT: 3000,
     SERVE_STATIC: false,
-    PROJECT_URL: JSON.stringify('https://tamsui.dev'),
+    PROJECT_URL: JSON.stringify('https://chichiwang.dev'),
   },
 };


### PR DESCRIPTION
## Description
Linked to Issue: #3
Update production project configuration `PROJECT_URL` to the intended production url.

## Changes
* Update production `PROJECT_URL` in `project-configs.js`

## Steps to QA
* Pull down and switch to this branch
* Run `npm run prod` and ensure in browser that the meta url and image tags contain the correct site urls ("https://chichiwang.dev")
  * Assets will not be properly delivered by the server in this mode unless you set the production project configuration `SERVE_STATIC` to `true`
 
![image](https://github.com/chichiwang/chichiwang.dev/assets/2304118/c2ff1c48-ee3d-4919-998b-5a546797b285)

