### PR TITLE
Create a baseline layout for the site

### DIFF
--- a/app/dataRoutes/__tests__/index.test.js
+++ b/app/dataRoutes/__tests__/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Layout from 'app/Layout';
+import Layout from 'app/layouts/Panda';
 
 import Resume from 'pages/Resume';
 import ErrorPage from 'pages/ErrorPage';
@@ -32,7 +32,7 @@ function MockedErrorPage() {
   );
 }
 
-jest.mock('app/Layout', function MockLayout() {
+jest.mock('app/layouts/Panda', function MockLayout() {
   return MockedLayout;
 });
 

--- a/app/dataRoutes/index.ts
+++ b/app/dataRoutes/index.ts
@@ -1,6 +1,6 @@
 import { RouteObject } from 'react-router-dom';
 
-import Layout from 'app/Layout';
+import Layout from 'app/layouts/Panda';
 
 import Resume from 'pages/Resume';
 import ResumeHandle from 'pages/Resume/handle';

--- a/app/layouts/Panda/__tests__/__snapshots__/index.test.js.snap
+++ b/app/layouts/Panda/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Panda layout matches no-child snapshot 1`] = `
+<html
+  lang="en"
+>
+  <head>
+    <title>
+      Layout Test
+    </title>
+  </head>
+  <body>
+    <section
+      className="page"
+    >
+      <main
+        className="content"
+      />
+    </section>
+  </body>
+</html>
+`;

--- a/app/layouts/Panda/__tests__/index.test.js
+++ b/app/layouts/Panda/__tests__/index.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
+import useResetScroll from 'app/hooks/useResetScroll';
+
+import Panda from '../index';
+
+function MockedHead() {
+  return (
+    <head>
+      <title>Layout Test</title>
+    </head>
+  );
+}
+
+jest.mock('app/Head', () => MockedHead);
+jest.mock('app/hooks/useResetScroll', () => jest.fn());
+
+function RouterWrappedLayout() {
+  return (
+    <MemoryRouter>
+      <Panda />
+    </MemoryRouter>
+  );
+}
+
+describe('Panda layout', () => {
+  beforeEach(() => {
+    useResetScroll.mockRestore();
+  });
+
+  test('matches no-child snapshot', () => {
+    const tree = renderer.create(<RouterWrappedLayout />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  test('invokes the useResetScroll hook', () => {
+    renderer.create(<RouterWrappedLayout />);
+
+    expect(useResetScroll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/layouts/Panda/index.tsx
+++ b/app/layouts/Panda/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+import useResetScroll from 'app/hooks/useResetScroll';
+
+import HTMLBody from 'app/HTMLBody';
+
+import styles from './styles.module.scss';
+
+function Panda() {
+  useResetScroll();
+
+  return (
+    <HTMLBody>
+      <section className={styles.page}>
+        <main className={styles.content}>
+          <Outlet />
+        </main>
+      </section>
+    </HTMLBody>
+  );
+}
+
+export default Panda;

--- a/app/layouts/Panda/styles.module.scss
+++ b/app/layouts/Panda/styles.module.scss
@@ -1,0 +1,14 @@
+@use 'sass:map';
+@use 'app/var.module';
+
+.page {
+  width: 100%;
+  min-height: 100vh;
+}
+
+.content {
+  position: relative;
+  max-width: map.get(var.$content, 'max-width');
+  margin: 0 auto;
+  font-size: map.get(var.$content, 'font-size');
+}


### PR DESCRIPTION
## Description
Linked to Issue: #3
Instrument a new baseline layout for the site (`app/layouts/Panda`). Replace the boilerplate layout with the new baseline layout in `app/dataRoutes`.

The new layout is called `Panda` because the current design thinking is that the primary colors for the site will be black and white.

**NOTE**: The boilerplate layout will be removed in a follow-up PR due to the size of change.

## Changes
* Create a new baseline layout `app/layouts/Panda/index.tsx`
  * Use `HTMLBody` and `useResetScroll`, but otherwise renders no other content for the time being
  * Can be extended with a nav/footer, etc in the future
* Replace the boilerplate layout `app/Layout` with `app/layout/Panda` in `app/dataRoutes/index.ts`

## Steps to QA
* Pull down and switch to this branch
* Run the app and ensure no issues
* Verify in browser the three routes in the site (`/`, `/error`, `/notfound`) render without issue, using a bare-bones layout (no UI outside of the page component contents, but still contains html, head, and body tags)
