### PR TITLE
ExternalLink component: open in the same tab

### DIFF
--- a/app/components/ExternalLink/__tests__/__snapshots__/index.test.js.snap
+++ b/app/components/ExternalLink/__tests__/__snapshots__/index.test.js.snap
@@ -4,8 +4,6 @@ exports[`ExternalLink Component className snapshot 1`] = `
 <a
   className="color-orange dotted-underline"
   href="https://developer.mozilla.org/"
-  rel="noreferrer"
-  target="_blank"
 >
   <b>
     Developer Documentation
@@ -16,8 +14,6 @@ exports[`ExternalLink Component className snapshot 1`] = `
 exports[`ExternalLink Component matches snapshot 1`] = `
 <a
   href="https://www.github.com"
-  rel="noreferrer"
-  target="_blank"
 >
   Repository
 </a>

--- a/app/components/ExternalLink/index.tsx
+++ b/app/components/ExternalLink/index.tsx
@@ -11,7 +11,7 @@ function ExternalLink({
   href,
 }: ExternalLinkProps) {
   return (
-    <a className={className} href={href} rel="noreferrer" target="_blank">
+    <a className={className} href={href}>
       {children}
     </a>
   );


### PR DESCRIPTION
## Description
Linked to Issue: N/A
Following recent [changes to Tamsui](https://github.com/chichiwang/tamsui/pull/157), the `ExternalLink` component is being updated to not open in a new tab as [advised by WCAG 2.0](https://www.w3.org/TR/WCAG20-TECHS/G200.html).

## Changes
* `app/components/ExternalLink/index.tsx` updated to not open in a new tab

## Steps to QA
* Ensure the code looks correct
* Pull down and switch to this branch
* Add an `ExternalLink` to a page that is plugged into the routes - ensure the link does not open in a new tab.
