### PR TITLE
Change default color for anchor tags

### DIFF
--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -19,7 +19,7 @@
   font-family: system-ui, sans-serif;
   margin: 0;
   background-color: map.get(var.$colors, "panda", "white");
-  color: map.get(var.$colors, "panda", "grey");
+  color: map.get(var.$colors, "panda", "black");
 }
 
 :global a,

--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -26,7 +26,7 @@
 :global a:hover,
 :global a:focus,
 :global a:visited {
-  color: map.get(var.$colors, "panda", "black");
+  color: map.get(var.$colors, "accent", "blue");
   text-decoration: none;
   font-weight: bold;
 }

--- a/app/var.module.scss
+++ b/app/var.module.scss
@@ -9,6 +9,12 @@ $colors: (
     "white": #F8F9FA,
     "lightGrey": #E9ECEF,
     "grey": #495057,
+  ),
+  "accent": (
+    "blue": #1679AB,
+    "navy": #574F7D,
+    "lightTeal": #DFF0EA,
+    "teal": #95ADBE,
   )
 );
 


### PR DESCRIPTION
## Description
Linked to Issue: #4
The [WCAG accessibility guidelines for links](https://www.w3.org/TR/2008/NOTE-WCAG20-TECHS-20081211/G183) whose color is the only visual cue of a link specifies that the following would be compliant:

> Colors that would provide 3:1 contrast with black words and 4.5:1 contrast with a white background

A blue was chosen for links on the page that has a 3.2:1 contrast with the text colors and a 4.57:1 contrast with the background color. This satisfies the requirement for AA accessibility for links. Additionally, links are tab-navigable with a default browser outline on focus.

A couple of colors have been added for accent on the site in addition to this blue used by links: navy, teal, and light teal.

## Changes
* Add a map `accent` to map `$colors` in `app/var.module.scss`
* Change the default body color to `black` and anchor color to `accent.blue` in `app/global.module.scss`

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in browser:
  * That the text is now black
  * On the `/notfound` page, link back to home is blue.
  * Use the [Wave extension](https://wave.webaim.org/extension/) or other accessibility tester to ensure no color contrast issues on `/notfound`
