### PR TITLE
Add basic fonts to site

### DIFF
--- a/app/global.module.scss
+++ b/app/global.module.scss
@@ -1,5 +1,6 @@
 @use "sass:map";
 @use "var.module";
+@use "mixins.module";
 
 :global html {
   box-sizing: border-box;
@@ -15,8 +16,8 @@
 }
 
 :global body {
+  @include mixins.font-slab-serif;
   font-size: 16px;
-  font-family: system-ui, sans-serif;
   margin: 0;
   background-color: map.get(var.$colors, "panda", "white");
   color: map.get(var.$colors, "panda", "black");
@@ -29,6 +30,15 @@
   color: map.get(var.$colors, "accent", "blue");
   text-decoration: none;
   font-weight: bold;
+}
+
+:global h1,
+:global h2,
+:global h3,
+:global h4,
+:global h5,
+:global h6 {
+  @include mixins.font-geometric-humanist;
 }
 
 :global h1 {

--- a/app/mixins.module.scss
+++ b/app/mixins.module.scss
@@ -1,0 +1,11 @@
+@mixin font-slab-serif {
+  font-family: Rockwell, 'Rockwell Nova', 'Roboto Slab', 'DejaVu Serif', 'Sitka Small', serif;
+}
+
+@mixin font-geometric-humanist {
+  font-family: Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif;
+}
+
+@mixin font-monospace-code {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+}


### PR DESCRIPTION
## Description
Linked to Issue: #5
After some deliberation it was decided to use [Modern Font Stacks](https://github.com/system-fonts/modern-font-stacks) font-family definitions rather than go with [Google Fonts](https://fonts.google.com/) or another open source font supplier to provide the fonts to the site.

The benefit of using Modern Font Stacks is that it leverages fonts available on all major OS's removing the need to load fonts at all - this reduces the k-weight of the site by a fraction, but more impactful: it removes the possibility of a flash of unstyled text on page load. The font already lives on the user's system and can be leveraged.

A modern sans-serif family was chosen for headings, and a clean serif family was chosen for the body text.

## Changes
* Create a `app/mixins.module.scss` module to house mixins for three font families:
  * `font-slab-serif` will set the font family to [slab serif](https://github.com/system-fonts/modern-font-stacks#slab-serif)
  * `font-geometric-humanist` will set the font family to [geometric humanist](https://github.com/system-fonts/modern-font-stacks#geometric-humanist)
  * `font-monospace-code` will set the font family to [monospace code](https://github.com/system-fonts/modern-font-stacks#monospace-code)
* `app/global.module.scss` updated to set the body to slab serif, and headings to geometric humanist

## Steps to QA
* Pull down and switch to this branch
* Verify the fonts have changed on all pages (`/`, `/error`, `/notfound`)
