### PR TITLE
Update site title, meta keywords, meta description

### DIFF
--- a/app/Head/__tests__/__snapshots__/index.test.js.snap
+++ b/app/Head/__tests__/__snapshots__/index.test.js.snap
@@ -6,18 +6,18 @@ exports[`Head component matches the no route head snapshot 1`] = `
     charSet="utf-8"
   />
   <title>
-    Tamsui: A Universal JavaScript Application Boilerplate
+    Chi-chi Wang: Software Engineer
   </title>
   <meta
     content="Chi-chi Wang"
     name="author"
   />
   <meta
-    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    content="Chi-chi Wang, Software Engineer, UI, JavaScript, Node.js, React"
     name="keywords"
   />
   <meta
-    content="An Express/React universal application boilerplate"
+    content="Chichi Wang: Software Engineer, JavaScript specialist"
     name="description"
   />
   <meta
@@ -83,18 +83,18 @@ exports[`Head component matches the route tags snapshot 1`] = `
     charSet="utf-8"
   />
   <title>
-    Tamsui: A Universal JavaScript Application Boilerplate
+    Chi-chi Wang: Software Engineer
   </title>
   <meta
     content="Chi-chi Wang"
     name="author"
   />
   <meta
-    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    content="Chi-chi Wang, Software Engineer, UI, JavaScript, Node.js, React"
     name="keywords"
   />
   <meta
-    content="An Express/React universal application boilerplate"
+    content="Chichi Wang: Software Engineer, JavaScript specialist"
     name="description"
   />
   <meta
@@ -168,18 +168,18 @@ exports[`Head component matches the route title snapshot 1`] = `
     charSet="utf-8"
   />
   <title>
-    route has PageHandle with title | Tamsui
+    route has PageHandle with title | Chi-chi Wang
   </title>
   <meta
     content="Chi-chi Wang"
     name="author"
   />
   <meta
-    content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+    content="Chi-chi Wang, Software Engineer, UI, JavaScript, Node.js, React"
     name="keywords"
   />
   <meta
-    content="An Express/React universal application boilerplate"
+    content="Chichi Wang: Software Engineer, JavaScript specialist"
     name="description"
   />
   <meta

--- a/app/Head/index.tsx
+++ b/app/Head/index.tsx
@@ -9,8 +9,8 @@ function Head() {
   const manifest: Manifest = useContext(ManifestContext);
   const head = useRouteHead();
 
-  const defaultTitle = 'Tamsui: A Universal JavaScript Application Boilerplate';
-  const titleSuffix = '| Tamsui';
+  const defaultTitle = 'Chi-chi Wang: Software Engineer';
+  const titleSuffix = '| Chi-chi Wang';
   const title = head?.title
     ? `${head.title} ${titleSuffix}`
     : defaultTitle;
@@ -24,9 +24,9 @@ function Head() {
       <meta name="author" content="Chi-chi Wang" />
       <meta
         name="keywords"
-        content="Tamsui, js, JavaScript, isomorphic, Node.js, React, TypeScript, Express, React-Router, Boilerplate"
+        content="Chi-chi Wang, Software Engineer, UI, JavaScript, Node.js, React"
       />
-      <meta name="description" content="An Express/React universal application boilerplate" />
+      <meta name="description" content="Chichi Wang: Software Engineer, JavaScript specialist" />
       <meta name="robots" content="all" />
       <meta name="viewport" content="width=device-width" />
       <link rel="stylesheet" type="text/css" href={`/${manifest['app.css']}`} />


### PR DESCRIPTION
## Description
Linked to Issue: #8
Update the site title, title suffix, meta description, and meta keywords in the app `Head` component

## Changes
* Update `app/Head/index.tsx` to change
  * Site title
  * Page title suffix
  * Meta keywords
  * Meta description

## Steps to QA
* Pull down and switch to this branch
* Verify in browser that the homepage title defaults to the new title
* Verify in browser the new page title suffix is applied on `/error` and `/notfound`
* Verify in browser the new meta tag content is correct
