### PR TITLE
Serve static directory with `serve-static`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "pino-http": "^9.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.22.3"
+        "react-router-dom": "^6.22.3",
+        "serve-static": "^1.16.2"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "pino-http": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "serve-static": "^1.16.2"
   }
 }

--- a/server/__tests__/index.test.js
+++ b/server/__tests__/index.test.js
@@ -1,11 +1,13 @@
 /* eslint global-require: 0, camelcase: 0 */
 import express from 'express';
+import serveStatic from 'serve-static';
 
 import logger from '../logger';
 import httpLogger from '../httpLogger';
 import appHandler from '../appHandler';
 
 jest.mock('express');
+jest.mock('serve-static', () => jest.fn((p) => p));
 
 jest.mock('../logger');
 jest.mock('../httpLogger');
@@ -95,7 +97,7 @@ describe('server', () => {
 
   describe('SERVE_STATIC config set to true', () => {
     test('has the expected number of middleware and static asset routes', () => {
-      expect(mockAppUse).toHaveBeenCalledTimes(4);
+      expect(mockAppUse).toHaveBeenCalledTimes(5);
     });
 
     test('serves the correct number of static routes', () => {
@@ -121,9 +123,9 @@ describe('server', () => {
     test('/static directory is served statically', () => {
       expect(express.static).toHaveBeenCalledWith(expect.stringMatching(/static/));
 
-      const stylesPath = express.static.mock.calls[2][0];
+      const staticPath = express.static.mock.calls[2][0];
 
-      expect(mockAppUse).toHaveBeenCalledWith('/static', mockExpressStatic(stylesPath));
+      expect(mockAppUse).toHaveBeenCalledWith('/static', mockExpressStatic(staticPath));
     });
   });
 
@@ -139,11 +141,19 @@ describe('server', () => {
     });
 
     test('has the expected number of middleware and static asset routes', () => {
-      expect(mockAppUse).toHaveBeenCalledTimes(1);
+      expect(mockAppUse).toHaveBeenCalledTimes(2);
     });
 
-    test('does not set up any static routes', () => {
+    test('does not register any static route', () => {
       expect(express.static).not.toHaveBeenCalled();
+    });
+
+    test('/static directory is served statically', () => {
+      expect(serveStatic).toHaveBeenCalledWith(expect.stringMatching(/static/));
+
+      const staticPath = serveStatic.mock.calls[0][0];
+
+      expect(mockAppUse).toHaveBeenCalledWith(staticPath);
     });
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 /* global PORT, SERVE_STATIC */
 import path from 'node:path';
+import serveStatic from 'serve-static';
 
 import express, {
   Express,
@@ -13,6 +14,7 @@ const app: Express = express();
 const port: Number = PORT;
 
 app.use(httpLogger);
+app.use(serveStatic(path.resolve(__dirname, 'static')));
 
 if (SERVE_STATIC) {
   app.use('/scripts', express.static(path.resolve(__dirname, 'scripts')));

--- a/static/.well-known/acme-challenge/health
+++ b/static/.well-known/acme-challenge/health
@@ -1,0 +1,1 @@
+accessible


### PR DESCRIPTION
## Description
Updating to match [Tamsui update](https://github.com/chichiwang/tamsui/pull/165)
Serve static files without extension from the `/static` directory using [serve-static](https://expressjs.com/id/resources/middleware/serve-static.html).

## Changes
* Add dependency `serve-static` to `package.json`
* Update tests `server/__tests__/index.test.js`
* Serve the `/static` directory using `serve-static` in `server/index.ts`
* Add test file `static/.well-known/acme-challenge/health`

## Steps to QA
* Pull down and switch to this branch
* Run the app and verify in browser that routing to `/.well-known/acme-challenge/health` triggers a download of a file `health` without a file extension
  * File should contain the text "accessible"
